### PR TITLE
Feature/filename based sharding ignore

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/syncthing/syncthing/cmd/syncthing/cmdutil"
 	"github.com/syncthing/syncthing/cmd/syncthing/decrypt"
 	"github.com/syncthing/syncthing/cmd/syncthing/generate"
+	"github.com/syncthing/syncthing/cmd/syncthing/purge"
 	_ "github.com/syncthing/syncthing/lib/automaxprocs"
 	"github.com/syncthing/syncthing/lib/build"
 	"github.com/syncthing/syncthing/lib/config"
@@ -132,6 +133,7 @@ var entrypoint struct {
 	Serve              serveOptions                 `cmd:"" help:"Run Syncthing"`
 	Generate           generate.CLI                 `cmd:"" help:"Generate key and config, then exit"`
 	Decrypt            decrypt.CLI                  `cmd:"" help:"Decrypt or verify an encrypted folder"`
+	Purge              purge.CLI                    `cmd:"" help:"Purge ignored local files of folder"`
 	Cli                cli.CLI                      `cmd:"" help:"Command line interface for Syncthing"`
 	InstallCompletions kongplete.InstallCompletions `cmd:"" help:"Print commands to install shell completions"`
 }

--- a/cmd/syncthing/purge/purge.go
+++ b/cmd/syncthing/purge/purge.go
@@ -1,0 +1,105 @@
+// Copyright (C) 2021 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Package decrypt implements the `syncthing decrypt` subcommand.
+package purge
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/syncthing/syncthing/lib/fs"
+	"github.com/syncthing/syncthing/lib/ignore"
+)
+
+type CLI struct {
+	Path       string `arg:"" required:"1" help:"Path to folder"`
+	IgnoreFile string `help:"Relative path, with respect to folder, to ignore file, if other than \".stignore\""`
+	Continue   bool   `help:"Continue processing next file in case of error, instead of aborting"`
+	Verbose    bool   `help:"Show verbose progress information"`
+	DryRun     bool   `help:"Don't actually delete anything"`
+}
+
+func (c *CLI) Run() error {
+	log.SetFlags(0)
+
+	if c.IgnoreFile == "" {
+		c.IgnoreFile = ".stignore"
+	}
+
+	if c.Verbose {
+		log.Printf("Purging %q", c.Path)
+	}
+
+	return c.walk()
+}
+
+// walk finds and processes every file in the folder
+func (c *CLI) walk() error {
+	srcFs := fs.NewFilesystem(fs.FilesystemTypeBasic, c.Path)
+	matcher := ignore.New(srcFs)
+	if c.Verbose {
+		log.Printf("Using ignore file %q", c.IgnoreFile)
+	}
+	matcher.Load(c.IgnoreFile)
+
+	if c.Verbose {
+		log.Printf("ignore patterns: %v", matcher.Patterns())
+	}
+
+	return srcFs.Walk(".", func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsRegular() {
+			return nil
+		}
+		if fs.IsInternal(path) {
+			return nil
+		}
+
+		return c.withContinue(c.process(srcFs, matcher, path))
+	})
+}
+
+// If --continue was set we just mention the error and return nil to
+// continue processing.
+func (c *CLI) withContinue(err error) error {
+	if err == nil {
+		return nil
+	}
+	if c.Continue {
+		log.Println("Warning:", err)
+		return nil
+	}
+	return err
+}
+
+func (c *CLI) process(srcFs fs.Filesystem, matcher *ignore.Matcher, path string) error {
+
+	if c.Verbose {
+		log.Printf("Processing %q", path)
+	}
+
+	// Check if the file is ignored
+	result := matcher.Match(path)
+	if result.IsDeletable() {
+		if c.Verbose {
+			log.Printf("Deleting %q", path)
+		}
+
+		if c.DryRun {
+			log.Printf("Dry run: would delete %q", path)
+			return nil
+		}
+
+		if err := srcFs.Remove(path); err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22.0
 
 require (
 	github.com/AudriusButkevicius/recli v0.0.7-0.20220911121932-d000ce8fbf0f
+	github.com/alecthomas/assert/v2 v2.11.0
 	github.com/alecthomas/kong v1.6.0
 	github.com/aws/aws-sdk-go v1.55.5
 	github.com/calmh/incontainer v1.0.0
@@ -50,6 +51,11 @@ require (
 )
 
 require (
+	github.com/alecthomas/repr v0.4.0 // indirect
+	github.com/hexops/gotextdiff v1.0.3 // indirect
+)
+
+require (
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
@@ -83,6 +89,7 @@ require (
 	github.com/prometheus/common v0.60.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/riywo/loginshell v0.0.0-20200815045211-7d26008be1ab // indirect
+	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/stretchr/testify v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,8 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5X
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/riywo/loginshell v0.0.0-20200815045211-7d26008be1ab h1:ZjX6I48eZSFetPb41dHudEyVr5v953N15TsNZXlkcWY=
 github.com/riywo/loginshell v0.0.0-20200815045211-7d26008be1ab/go.mod h1:/PfPXh0EntGc3QAAyUaviy4S9tzy4Zp0e2ilq4voC6E=
-github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
-github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
+github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
+github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sclevine/spec v1.4.0 h1:z/Q9idDcay5m5irkZ28M7PtQM4aOISzOpj4bUPkDee8=

--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -5,7 +5,7 @@
         <li ng-class="{'disabled': currentFolder._editing == 'new-ignores'}" class="active"><a data-toggle="tab" href="{{currentFolder._editing == 'new-ignores' ? '' : '#folder-general'}}"><span class="fas fa-cog"></span> <span translate>General</span></a></li>
         <li ng-class="{'disabled': currentFolder._editing == 'new-ignores'}"><a data-toggle="tab" href="{{currentFolder._editing == 'new-ignores' ? '' : '#folder-sharing'}}"><span class="fas fa-share-alt"></span> <span translate>Sharing</span></a></li>
         <li ng-class="{'disabled': currentFolder._editing == 'new-ignores'}"><a data-toggle="tab" href="{{currentFolder._editing == 'new-ignores' ? '' : '#folder-versioning'}}"><span class="fa fa-files-o"></span> <span translate>File Versioning</span></a></li>
-        <li ng-class="{'disabled': currentFolder._recvEnc}"><a data-toggle="tab" href="{{currentFolder._recvEnc ? '' : '#folder-ignores'}}"><span class="fas fa-filter"></span> <span translate>Ignore Patterns</span></a></li>
+        <li ng-class="{'disabled': currentFolder._editing == 'new-ignores'}"><a data-toggle="tab" href="{{'#folder-ignores'}}"><span class="fas fa-filter"></span> <span translate>Ignore Patterns</span></a></li>
         <li ng-class="{'disabled': currentFolder._editing == 'new-ignores'}"><a data-toggle="tab" href="{{currentFolder._editing == 'new-ignores' ? '' : '#folder-advanced'}}"><span class="fas fa-cogs"></span> <span translate>Advanced</span></a></li>
       </ul>
       <div class="tab-content">

--- a/lib/config/foldertype.go
+++ b/lib/config/foldertype.go
@@ -30,6 +30,11 @@ func (t FolderType) String() string {
 	}
 }
 
+func (t FolderType) SupportsIgnores() bool {
+	// return t != FolderTypeReceiveEncrypted
+	return true
+}
+
 func (t FolderType) MarshalText() ([]byte, error) {
 	return []byte(t.String()), nil
 }

--- a/lib/config/foldertype.go
+++ b/lib/config/foldertype.go
@@ -32,6 +32,8 @@ func (t FolderType) String() string {
 
 func (t FolderType) SupportsIgnores() bool {
 	// return t != FolderTypeReceiveEncrypted
+	// To be able to use the sharding feature, ignores must be enabled
+	// TODO: discuss with maintainer how this can be solved properly
 	return true
 }
 

--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -515,6 +515,17 @@ func parseIgnoreFile(fs fs.Filesystem, fd io.Reader, currentFile string, cd Chan
 			continue
 		case strings.HasPrefix(line, "//"):
 			continue
+		case strings.HasPrefix(line, ShardExcludePrefixCommon):
+			matcher, err := ShardExcludeParse(line)
+			if err != nil {
+				return lines, nil, parseError(err)
+			}
+			patterns = append(patterns, Pattern{
+				pattern: line,
+				match:   matcher,
+				result:  matcher.ignoreR,
+			})
+			continue
 		}
 
 		line = filepath.ToSlash(line)

--- a/lib/ignore/ignore_shards.go
+++ b/lib/ignore/ignore_shards.go
@@ -1,0 +1,116 @@
+package ignore
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"strings"
+
+	"github.com/syncthing/syncthing/lib/ignore/ignoreresult"
+)
+
+const ShardExcludePrefixCommon = "#shard-exclude"
+const ShardExcludePrefix = ShardExcludePrefixCommon + ":"
+const ShardExcludePurgePrefix = ShardExcludePrefixCommon + "-purge:"
+
+func HashIsBelowStart(hash, range_start []byte) bool {
+	minLen := min(len(hash), len(range_start))
+	for i := 0; i < minLen; i++ {
+		if hash[i] < range_start[i] {
+			return true
+		}
+		if hash[i] > range_start[i] {
+			return false
+		}
+	}
+	return false
+}
+
+func HashIsAboveEnd(hash, range_end []byte) bool {
+	minLen := min(len(hash), len(range_end))
+	for i := 0; i < minLen; i++ {
+		if hash[i] > range_end[i] {
+			return true
+		}
+		if hash[i] < range_end[i] {
+			return false
+		}
+	}
+	return false
+}
+
+type SingleShardRange struct {
+	start_incl []byte
+	end_incl   []byte
+}
+
+func (s SingleShardRange) IsInRange(hash []byte) bool {
+	return !HashIsBelowStart(hash, s.start_incl) && !HashIsAboveEnd(hash, s.end_incl)
+}
+
+type ShardExclude struct {
+	excludes []SingleShardRange
+	ignoreR  ignoreresult.R
+}
+
+func (s ShardExclude) MatchHash(sha256 []byte) bool {
+	excluded := false
+	for _, ex := range s.excludes {
+		excluded = excluded || ex.IsInRange(sha256)
+	}
+	return excluded
+}
+
+func (s ShardExclude) Match(file string) bool {
+	sha256 := sha256.Sum256([]byte(file))
+	return s.MatchHash(sha256[:])
+}
+
+func ShardRangeParseStartHex(hex_start string) ([]byte, error) {
+	if len(hex_start)%2 != 0 {
+		hex_start = hex_start + "0"
+	}
+	return hex.AppendDecode(nil, []byte(hex_start))
+}
+
+func ShardRangeParseEndHex(hex_end string) ([]byte, error) {
+	if len(hex_end)%2 != 0 {
+		hex_end = hex_end + "f"
+	}
+	return hex.AppendDecode(nil, []byte(hex_end))
+}
+
+func ShardExcludeParse(line string) (ShardExclude, error) {
+	var se ShardExclude
+
+	switch {
+	case strings.HasPrefix(line, ShardExcludePrefix):
+		line = line[len(ShardExcludePrefix):]
+		se.ignoreR = ignoreresult.Ignored
+	case strings.HasPrefix(line, ShardExcludePurgePrefix):
+		line = line[len(ShardExcludePurgePrefix):]
+		se.ignoreR = ignoreresult.IgnoredDeletable
+	default:
+		return se, errors.New("not a shard exclude line")
+	}
+
+	for _, part := range strings.Split(line, ",") {
+		if part == "" {
+			continue
+		}
+		var sse SingleShardRange
+		parts := strings.Split(part, "-")
+		if len(parts) != 2 {
+			return se, errors.New("invalid shard exclude line")
+		}
+		var err1, err2 error
+		sse.start_incl, err1 = ShardRangeParseStartHex(parts[0])
+		sse.end_incl, err2 = ShardRangeParseEndHex(parts[1])
+		if err1 != nil || err2 != nil {
+			return se, errors.New("invalid shard exclude line")
+		}
+
+		se.excludes = append(se.excludes, sse)
+	}
+	return se, nil
+}

--- a/lib/ignore/ignore_shards.go
+++ b/lib/ignore/ignore_shards.go
@@ -1,3 +1,9 @@
+// Copyright (C) 2014 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package ignore
 
 import (

--- a/lib/ignore/ignore_shards_test.go
+++ b/lib/ignore/ignore_shards_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) 2014 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package ignore
 
 import (

--- a/lib/ignore/ignore_shards_test.go
+++ b/lib/ignore/ignore_shards_test.go
@@ -1,0 +1,117 @@
+package ignore
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+)
+
+func TestHashIsAboveRangeStart(t *testing.T) {
+
+	testFunc := func(t *testing.T, hash string, start string, expected bool) {
+		hashbytes, err := hex.DecodeString(hash)
+		assert.NoError(t, err)
+		start_bytes, err := ShardRangeParseStartHex(start)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, HashIsBelowStart(hashbytes, start_bytes))
+	}
+
+	below := true
+
+	testFunc(t, "0000", "0", !below)
+	testFunc(t, "0000", "00", !below)
+	testFunc(t, "0000", "000", !below)
+
+	testFunc(t, "1111", "1", !below)
+	testFunc(t, "1111", "11", !below)
+	testFunc(t, "1111", "111", !below)
+
+	testFunc(t, "ffff", "f", !below)
+	testFunc(t, "ffff", "ff", !below)
+	testFunc(t, "ffff", "fff", !below)
+
+	testFunc(t, "1111", "2", below)
+	testFunc(t, "1111", "12", below)
+	testFunc(t, "1111", "112", below)
+	testFunc(t, "1111", "1112", below)
+}
+
+func TestHashIsBelowRangeEnd(t *testing.T) {
+
+	testFunc := func(t *testing.T, hash string, end string, expected bool) {
+		hashbytes, err := hex.DecodeString(hash)
+		assert.NoError(t, err)
+		end_bytes, err := ShardRangeParseEndHex(end)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, HashIsAboveEnd(hashbytes, end_bytes))
+	}
+
+	above := true
+
+	testFunc(t, "ffff", "f", !above)
+	testFunc(t, "ffff", "ff", !above)
+	testFunc(t, "ffff", "fff", !above)
+	testFunc(t, "ffff", "ffff", !above)
+	testFunc(t, "efff", "e", !above)
+	testFunc(t, "0001", "0", !above)
+	testFunc(t, "10", "1", !above)
+
+	testFunc(t, "01", "00", above)
+	testFunc(t, "1000", "0", above)
+	testFunc(t, "ffff", "fffe", above)
+}
+
+func TestShardExcludeAll(t *testing.T) {
+	se, err := ShardExcludeParse("#shard-exclude:0-f")
+	if err != nil {
+		t.Fatalf("Failed to parse shard exclude: %v", err)
+	}
+
+	testFunc := func(t *testing.T, hash string, expected bool) {
+		hashbytes, err := hex.DecodeString(hash)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, se.MatchHash(hashbytes))
+	}
+
+	testFunc(t, "0000", true)
+	testFunc(t, "1000", true)
+	testFunc(t, "efff", true)
+	testFunc(t, "ffff", true)
+}
+
+func TestShardExcludeFirstAndLast16th(t *testing.T) {
+	se, err := ShardExcludeParse("#shard-exclude:0-0,f-f")
+	if err != nil {
+		t.Fatalf("Failed to parse shard exclude: %v", err)
+	}
+
+	testFunc := func(t *testing.T, hash string, expected bool) {
+		hashbytes, err := hex.DecodeString(hash)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, se.MatchHash(hashbytes))
+	}
+
+	testFunc(t, "0000", true)
+	testFunc(t, "0fff", true)
+	testFunc(t, "1000", false)
+	testFunc(t, "5000", false)
+	testFunc(t, "a000", false)
+	testFunc(t, "efff", false)
+	testFunc(t, "f000", true)
+	testFunc(t, "ffff", true)
+}
+
+func TestShardExcludeFilenameBased(t *testing.T) {
+	se, err := ShardExcludeParse("#shard-exclude:734-734")
+	if err != nil {
+		t.Fatalf("Failed to parse shard exclude: %v", err)
+	}
+
+	testFunc := func(t *testing.T, filename string, expected bool) {
+		assert.Equal(t, expected, se.Match(filename))
+	}
+
+	testFunc(t, "hello.txt", true)
+	testFunc(t, "world.txt", false)
+}

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -317,7 +317,7 @@ func (f *folder) getHealthErrorAndLoadIgnores() error {
 	if err := f.getHealthErrorWithoutIgnores(); err != nil {
 		return err
 	}
-	if f.Type != config.FolderTypeReceiveEncrypted {
+	if f.Type.SupportsIgnores() {
 		if err := f.ignores.Load(".stignore"); err != nil && !fs.IsNotExist(err) {
 			return fmt.Errorf("loading ignores: %w", err)
 		}

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1791,7 +1791,9 @@ func (m *model) handleAutoAccepts(deviceID protocol.DeviceID, folder protocol.Fo
 				}
 				fcfg.Versioning.Reset()
 				// Other necessary settings are ensured by FolderConfiguration itself
-			} else {
+			}
+
+			if fcfg.Type.SupportsIgnores() {
 				ignores := m.cfg.DefaultIgnores()
 				if err := m.setIgnores(fcfg, ignores.Lines); err != nil {
 					l.Warnf("Failed to apply default ignores to auto-accepted folder %s at path %s: %v", folder.Description(), fcfg.Path, err)

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -329,7 +329,9 @@ func (m *model) fatal(err error) {
 // Need to hold lock on m.mut when calling this.
 func (m *model) addAndStartFolderLocked(cfg config.FolderConfiguration, fset *db.FileSet, cacheIgnoredFiles bool) {
 	ignores := ignore.New(cfg.Filesystem(nil), ignore.WithCache(cacheIgnoredFiles))
-	if cfg.Type != config.FolderTypeReceiveEncrypted {
+	//doLoadIgnores := cfg.Type != config.FolderTypeReceiveEncrypted
+	doLoadIgnores := true
+	if doLoadIgnores {
 		if err := ignores.Load(".stignore"); err != nil && !fs.IsNotExist(err) {
 			l.Warnln("Loading ignores:", err)
 		}

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -329,9 +329,7 @@ func (m *model) fatal(err error) {
 // Need to hold lock on m.mut when calling this.
 func (m *model) addAndStartFolderLocked(cfg config.FolderConfiguration, fset *db.FileSet, cacheIgnoredFiles bool) {
 	ignores := ignore.New(cfg.Filesystem(nil), ignore.WithCache(cacheIgnoredFiles))
-	//doLoadIgnores := cfg.Type != config.FolderTypeReceiveEncrypted
-	doLoadIgnores := true
-	if doLoadIgnores {
+	if cfg.Type.SupportsIgnores() {
 		if err := ignores.Load(".stignore"); err != nil && !fs.IsNotExist(err) {
 			l.Warnln("Loading ignores:", err)
 		}
@@ -2211,7 +2209,7 @@ func (m *model) LoadIgnores(folder string) ([]string, []string, error) {
 		}
 	}
 
-	if cfg.Type == config.FolderTypeReceiveEncrypted {
+	if !cfg.Type.SupportsIgnores() {
 		return nil, nil, nil
 	}
 


### PR DESCRIPTION
### Purpose

"Sharding" is meant to describe a technique that distributes a large set of data onto multiple nodes of a cluster.
Benefits are
- that the total amount of data in the dataset can be larger than the memory of each individual node.
- that the write and read operation of data of the dataset can be distributed and such be faster than with a single node.
- that if desired a redundancy level can be achieved such that if multiple nodes fails, still all data can be read. This comes with cost of write speed and reduced maximum total size of the dataset.

This PR allows to use special new ignore-patterns to define sharded data distribution based on the hash of the filename.
This has the benefit of more random and equal distribution of the data.

Additionally, I extended the command line tool functionality by a "purge" function that deletes ignored files. This is useful for the case when the ignore-ranges are adapted and thus, some the the locally stored data is not desired on the corresponding node anymore

ATTENTION:
This PR should not yet be merged as it's implementation contains a unresolved conflict. To be able to do the sharding also for encrypted folders (which is my personal main usecase), I had to re-enable the ignore patterns for them again.
I would like to do a discussion about the best integration of it. E.g. allowing only shard-ignores for encrypted folders.

### Testing

I added some low level unit-tests to ensure that the the parsing and its filtering of the new ignore patterns for as expected. I did manual tests on my own NUC-PC cluster which was successfull.

### Screenshots

![grafik](https://github.com/user-attachments/assets/8e9be222-0029-452d-971f-420d7101e9e0)
![grafik](https://github.com/user-attachments/assets/5cd0dfa3-86a8-412d-93e4-3459323c9d54)

### Documentation

The idea is that one can define multiple arbitrary fine ranges based on the hexadecimal representation of the sha256 hash of the filenames.
E.g.

```
0-7 -> 00000000 ... 7fffffff
8-f -> 80000000 ... ffffffff

000-007 -> 00000000 ... 007fffffffff
008-00f -> 00800000 ... 00ffffffffff
010-017 -> 01000000 ... 017fffffffff
018-01f -> 01800000 ... 01ffffffffff
.....
```

#### Manual calculation of the ranges

e.g. by excel:

![grafik](https://github.com/user-attachments/assets/2f3dee88-c8ab-43c8-a0a4-86be8212accb)
